### PR TITLE
Allow custom outfiles in parallisation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,16 +1,12 @@
 Package: rport
 Type: Package
 Title: Connection management and SQL parallelisation for R analytics on big database clusters.
-Version: 1.0.0
-Date: 2018-03-29
+Version: 1.0.1
+Date: 2018-05-08
 Author: Nikola Chochkov
 Maintainer: Nikola Chochkov <nikola@adjust.com>
 Description: Provides facilities for:
-    * Handling multiple database connections within one R session
-    * Caching results from long SQL statements in development
-    * Parallel jobs processing
-    * Building UNIX executables
-    * Organizing the growing codebase
+    * Connection management and SQL parallelisation for R analytics on various PostgreSQL clustering scenarios
 License: MIT License
 Depends:
     data.table,yaml,parallel,RPostgreSQL

--- a/man/db.Rd
+++ b/man/db.Rd
@@ -4,7 +4,7 @@
 \alias{db}
 \title{Read from a Database (currently only PostgreSQL) connection.}
 \usage{
-db(con.names, sql, params = c(), cores = 4)
+db(con.names, sql, params = c(), cores = 4, outfile = "")
 }
 \arguments{
 \item{con.names}{a vector of connection names as defined in database.yml (or
@@ -34,6 +34,8 @@ important against SQL injection. For example, to get id=123:
 
 \item{cores}{determines the size of the parallel cluster for parallel
 queries.}
+
+\item{outfile}{the outfile variable passed on to makeCluster}
 }
 \description{
 Read from a Database (currently only PostgreSQL) connection.

--- a/tests/integration/rport.sh
+++ b/tests/integration/rport.sh
@@ -45,4 +45,10 @@ assert_match_count 'Max DB connections limit by the R driver hit, reconnecting. 
 assert_match_count 'Connection closed successfully.' $OUTPUT_DIR/max_con 0
 assert_match_count 'Done: db1' $OUTPUT_DIR/max_con 2
 
+# Passes the output param to makeCluster
+query "db(c('db1', 'db2'), 'select 1')" > $OUTPUT_DIR/no-output
+assert_match_count '^.*$' $OUTPUT_DIR/no-output 9
+query "db(c('db1', 'db2'), 'select 1', outfile='/dev/null')" > $OUTPUT_DIR/no-output
+assert_match_count '^.*$' $OUTPUT_DIR/no-output 3
+
 echo "OK"


### PR DESCRIPTION
This PR makes it possible for silencing (or redirecting) the output from parallel nodes like this:

```R
db(.SHARDS, sql, params, cores=16, outfile='/dev/null')
```

This will spawn a cluster normally using `makeCluster` and pass the `outfile` to it.