### PR TITLE
application_name for db connection is provided as a constant instead of reading from yml file

### DIFF
--- a/R/rport.R
+++ b/R/rport.R
@@ -268,7 +268,7 @@ db.disconnect <- function(con.name=NA) {
     db.disconnect()
   }
 
-  .dbConnect(drv=d, application_name=conninfo$application_name,
+  .dbConnect(drv=d, application_name='rport',
                   dbname=conninfo$database, user=conninfo$user,
                   password=conninfo$password, port=conninfo$port,
                   host=conninfo$host)


### PR DESCRIPTION
Since `application_name` for `.dbConnect` is always the same(`rport`), it is removed from the yaml file and added as a hardcoded parameter to `.dbConnect`

- [ ] The PR is not fully tested, should be tested before merge