### PR TITLE
Remove text which is not in section

### DIFF
--- a/man/rport-package.Rd
+++ b/man/rport-package.Rd
@@ -29,7 +29,6 @@ Maintainer: Who to complain to <yourfault@somewhere.net>
 \references{
 ~~ Literature or other references for background information ~~
 }
-~~ Optionally other standard keywords, one per line, from file KEYWORDS in the R documentation directory ~~
 \keyword{ package }
 \seealso{
 ~~ Optional links to other man pages, e.g. ~~


### PR DESCRIPTION
Removes useless Doc string that breaks installation on R 4.0